### PR TITLE
fix: pass headers instead of request to authenticate

### DIFF
--- a/client/src/auth.ts
+++ b/client/src/auth.ts
@@ -3,14 +3,14 @@ import { SupabaseClient } from "@supabase/supabase-js";
 import { AppError, AuthResult, Logger } from "./types";
 
 export const authenticate = (
-  request: Request,
+  headers: Headers,
   supabase: SupabaseClient,
   logger: Logger,
 ): Effect.Effect<AuthResult, AppError> =>
   pipe(
     Effect.tryPromise({
       try: async () => {
-        const authHeader = request.headers.get("Authorization");
+        const authHeader = headers.get("Authorization");
         if (authHeader && authHeader.startsWith("Bearer ")) {
           const apiKey = authHeader.split(" ")[1];
           const { data: userId, error: apiKeyError } = await supabase

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -55,9 +55,9 @@ export class KeyHippo {
     );
   }
 
-  async authenticate(request: Request) {
+  async authenticate(headers: Headers) {
     return Effect.runPromise(
-      authenticateEffect(request, this.supabase, this.logger),
+      authenticateEffect(headers, this.supabase, this.logger),
     );
   }
 }

--- a/client/tests/keyhippo-client.test.ts
+++ b/client/tests/keyhippo-client.test.ts
@@ -68,13 +68,11 @@ describe("KeyHippo Client Tests", () => {
       keyDescription,
     );
 
-    const mockRequest = new Request("https://example.com", {
-      headers: {
-        Authorization: `Bearer ${createdKey.apiKey}`,
-      },
+    const mockHeaders = new Headers({
+      Authorization: `Bearer ${createdKey.apiKey}`,
     });
 
-    const authResult = await testSetup.keyHippo.authenticate(mockRequest);
+    const authResult = await testSetup.keyHippo.authenticate(mockHeaders);
 
     expect(authResult).toHaveProperty("userId");
     expect(authResult).toHaveProperty("supabase");


### PR DESCRIPTION
Hi @david-r-cox,

_note: I was in between opening an issue or PR, and thought this would be more efficient in case this aligns with your vision. Do suggest otherwise if any preference._

I added now the final piece of the flow with `keyHippo.authenticate()` and I noticed that I'm forced to pass the entire `Request` object. Even though it is expectable to be available, the use case where I'm running it doesn't have the whole request object available.

You can check the PR with the authentication changes here: https://github.com/Design-System-Project/platform/pull/28
I'm using trpc along with NextJS and I don't have the response object in a server component context.

In the meantime I'm simply casting the response object so typescript doesn't complain:

```ts
  const keyHippo = new KeyHippo(supabase);
  const { userId } = await keyHippo.authenticate({
    headers,
  } as Request);
```

But I think it would be nicer for the API to accept only the headers object:

```ts
  const keyHippo = new KeyHippo(supabase);
  const { userId } = await keyHippo.authenticate(opts.headers);
```

or even just the authorization header or api key itself:

```ts
  const keyHippo = new KeyHippo(supabase);
  const { userId } = await keyHippo.authenticate(headers.get("Authorization"));
```


 What do you think?