### PR TITLE
v1.0.1: Implement audit log forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Features:
 
 ```sql
 select dbdev.install('keyhippo@keyhippo');
-create extension "keyhippo@keyhippo" version '1.0.0';
+create extension "keyhippo@keyhippo" version '1.0.1';
 ```
 
 Consult [database.dev](https://database.dev/keyhippo/keyhippo) for version updates.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Features:
 
 ```sql
 select dbdev.install('keyhippo@keyhippo');
-create extension "keyhippo@keyhippo" version '0.0.42';
+create extension "keyhippo@keyhippo" version '1.0.0';
 ```
 
 Consult [database.dev](https://database.dev/keyhippo/keyhippo) for version updates.

--- a/extension/README.md
+++ b/extension/README.md
@@ -53,55 +53,11 @@ Rotate an API key (revoke the old one, create a new one):
 SELECT * FROM keyhippo.rotate_api_key('<old_api_key_id>');
 ```
 
-### RLS Policy Integration
-
-Example policy combining user authentication and permission checks:
-
-```sql
-CREATE POLICY "owner_access"
-ON "public"."resource_table"
-FOR SELECT
-USING (
-  keyhippo.current_user_context().user_id = resource_table.owner_id
-  AND keyhippo.authorize('manage_resources')
-);
-```
-
-This policy allows access when the user is authenticated and has the necessary permission.
-
-### RBAC Management
-
-Create and manage roles, groups, and permissions:
-
-```sql
--- Create a new group
-SELECT keyhippo_rbac.create_group('Developers', 'Group for developer users') AS group_id;
-
--- Create a new role
-SELECT keyhippo_rbac.create_role('Developer', 'Developer role', '<group_id>', 'user') AS role_id;
-
--- Assign a permission to the role
-SELECT keyhippo_rbac.assign_permission_to_role('<role_id>', 'manage_resources');
-
--- Assign the role to a user
-SELECT keyhippo_rbac.assign_role_to_user('<user_id>', '<group_id>', '<role_id>');
-```
-
-### Impersonation Functions
-
-Admins can act on behalf of other users:
-
-```sql
-CALL keyhippo_impersonation.login_as_user('<user_id>');
-
--- Perform actions as the impersonated user
-
-CALL keyhippo_impersonation.logout();
-```
+Full usage details can be found on [GitHub](https://github.com/integrated-reasoning/KeyHippo/blob/main/README.md).
 
 ## Integration with Supabase
 
-KeyHippo integrates seamlessly with Supabase and PostgREST, enabling API key and RBAC functionality within your existing stack.
+KeyHippo integrates with Supabase and PostgREST, enabling API key and RBAC functionality within your existing stack.
 
 ## Security Highlights
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -8,7 +8,7 @@ To install the KeyHippo extension in your PostgreSQL database:
 
 ```sql
 select dbdev.install('keyhippo@keyhippo');
-create extension "keyhippo@keyhippo" version '0.0.42';
+create extension "keyhippo@keyhippo" version '1.0.0';
 ```
 
 Consult [database.dev](https://database.dev/keyhippo/keyhippo) for version updates.

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,21 +1,61 @@
 # KeyHippo PostgreSQL Extension
 
-This directory contains the PostgreSQL extension for KeyHippo, which extends Supabase's Row Level Security (RLS) to support API key authentication and Role-Based Access Control (RBAC) directly in Postgres.
+KeyHippo extends Supabase's Row Level Security (RLS) to support API key authentication and Role-Based Access Control (RBAC) directly in Postgres.
 
 ## Installation
 
-To install the KeyHippo extension in your PostgreSQL database:
+Install the KeyHippo extension in your PostgreSQL database:
 
 ```sql
 select dbdev.install('keyhippo@keyhippo');
 create extension "keyhippo@keyhippo" version '1.0.0';
 ```
 
-Consult [database.dev](https://database.dev/keyhippo/keyhippo) for version updates.
+For updates, visit the [KeyHippo extension catalog entry](https://database.dev/keyhippo/keyhippo).
 
-## Usage in RLS Policies
+## Core Features
 
-Once installed, you can use KeyHippo functions in your RLS policies. For example:
+### API Key Authentication
+
+KeyHippo enables secure API key management directly in Postgres. Each API key is hashed for storage, ensuring plaintext keys are never exposed.
+
+### Unified RLS Policies
+
+With KeyHippo, session tokens and API keys can coexist under unified RLS policies, simplifying authentication logic.
+
+### Role-Based Access Control (RBAC)
+
+Define fine-grained access control through groups, roles, and permissions that integrate seamlessly with your database.
+
+### Impersonation
+
+Administrators can impersonate users for troubleshooting or support tasks without compromising security.
+
+## Usage
+
+### API Key Management
+
+Generate an API key for an authenticated user:
+
+```sql
+SELECT * FROM keyhippo.create_api_key('Primary API Key', 'default');
+```
+
+Revoke an API key:
+
+```sql
+SELECT keyhippo.revoke_api_key('<api_key_id>');
+```
+
+Rotate an API key (revoke the old one, create a new one):
+
+```sql
+SELECT * FROM keyhippo.rotate_api_key('<old_api_key_id>');
+```
+
+### RLS Policy Integration
+
+Example policy combining user authentication and permission checks:
 
 ```sql
 CREATE POLICY "owner_access"
@@ -27,32 +67,56 @@ USING (
 );
 ```
 
-This policy allows access when the user is authenticated via a session token or a valid API key and has the 'manage_resources' permission.
+This policy allows access when the user is authenticated and has the necessary permission.
 
-## Available Functions
+### RBAC Management
 
-- `keyhippo.create_api_key(description TEXT, scope_name TEXT DEFAULT NULL)`: Creates a new API key for the current authenticated user.
-- `keyhippo.revoke_api_key(api_key_id UUID)`: Revokes an existing API key.
-- `keyhippo.rotate_api_key(old_api_key_id UUID)`: Rotates an API key by revoking the old one and creating a new one.
-- `keyhippo.current_user_context()`: Returns the current user's ID, scope, and permissions.
-- `keyhippo.authorize(requested_permission keyhippo.app_permission)`: Checks if the current user has the requested permission.
+Create and manage roles, groups, and permissions:
 
-### RBAC Management Functions
+```sql
+-- Create a new group
+SELECT keyhippo_rbac.create_group('Developers', 'Group for developer users') AS group_id;
 
-- `keyhippo_rbac.create_group(name TEXT, description TEXT)`: Creates a new group.
-- `keyhippo_rbac.create_role(name TEXT, description TEXT, group_id UUID, role_type keyhippo.app_role)`: Creates a new role within a group.
-- `keyhippo_rbac.assign_permission_to_role(role_id UUID, permission_name keyhippo.app_permission)`: Assigns a permission to a role.
-- `keyhippo_rbac.assign_role_to_user(user_id UUID, group_id UUID, role_id UUID)`: Assigns a role to a user within a group.
+-- Create a new role
+SELECT keyhippo_rbac.create_role('Developer', 'Developer role', '<group_id>', 'user') AS role_id;
+
+-- Assign a permission to the role
+SELECT keyhippo_rbac.assign_permission_to_role('<role_id>', 'manage_resources');
+
+-- Assign the role to a user
+SELECT keyhippo_rbac.assign_role_to_user('<user_id>', '<group_id>', '<role_id>');
+```
 
 ### Impersonation Functions
 
-- `keyhippo_impersonation.login_as_user(user_id UUID)`: Allows an admin to impersonate another user.
-- `keyhippo_impersonation.logout()`: Ends an impersonation session.
+Admins can act on behalf of other users:
 
-## Contributing
+```sql
+CALL keyhippo_impersonation.login_as_user('<user_id>');
 
-We welcome contributions to the KeyHippo extension. Please see our [Contributing Guide](/docs/Contributing.md) for more information.
+-- Perform actions as the impersonated user
+
+CALL keyhippo_impersonation.logout();
+```
+
+## Integration with Supabase
+
+KeyHippo integrates seamlessly with Supabase and PostgREST, enabling API key and RBAC functionality within your existing stack.
+
+## Security Highlights
+
+- **Hashed Keys:** Only key hashes are stored, ensuring plaintext keys are unavailable after creation.
+- **Scoped Permissions:** API keys include scoping to restrict their usage.
+- **Session Interoperability:** Works alongside session-based authentication.
+
+## Contribution
+
+Contributions are welcome. See our [Contributing Guide](https://github.com/integrated-reasoning/KeyHippo/blob/main/CONTRIBUTING.md) for details.
 
 ## License
 
-The KeyHippo PostgreSQL extension is distributed under the MIT license. See the [LICENSE](../LICENSE) file in the root directory for details.
+KeyHippo is distributed under the MIT license. See the [LICENSE](https://github.com/integrated-reasoning/KeyHippo/blob/main/LICENSE) file for more information.
+
+## Support
+
+For technical issues, open a GitHub issue. For commercial support, visit [keyhippo.com](https://keyhippo.com).

--- a/extension/README.md
+++ b/extension/README.md
@@ -8,7 +8,7 @@ Install the KeyHippo extension in your PostgreSQL database:
 
 ```sql
 select dbdev.install('keyhippo@keyhippo');
-create extension "keyhippo@keyhippo" version '1.0.0';
+create extension "keyhippo@keyhippo" version '1.0.1';
 ```
 
 For updates, visit the [KeyHippo extension catalog entry](https://database.dev/keyhippo/keyhippo).

--- a/extension/keyhippo--0.0.42.sql
+++ b/extension/keyhippo--0.0.42.sql
@@ -1073,7 +1073,7 @@ DECLARE
 BEGIN
     -- Upsert the default value for the audit log endpoint
     INSERT INTO keyhippo_internal.config (key, value, description)
-        VALUES ('audit_log_endpoint', 'https://app.keyhippo.com/api/echo', 'Endpoint for sending audit log notifications')
+        VALUES ('audit_log_endpoint', 'https://app.keyhippo.com/api/ingest', 'Endpoint for sending audit log notifications')
     ON CONFLICT (key)
         DO UPDATE SET
             value = EXCLUDED.value, description = EXCLUDED.description;

--- a/extension/keyhippo--0.0.42.sql
+++ b/extension/keyhippo--0.0.42.sql
@@ -221,19 +221,6 @@ DECLARE
     v_installation_uuid uuid;
     v_enable_http_logging boolean;
 BEGIN
-    -- Get the endpoint and configuration from the config table
-    SELECT
-        value INTO v_endpoint
-    FROM
-        keyhippo_internal.config
-    WHERE
-        key = 'audit_log_endpoint';
-    SELECT
-        value::uuid INTO v_installation_uuid
-    FROM
-        keyhippo_internal.config
-    WHERE
-        key = 'installation_uuid';
     SELECT
         value::boolean INTO v_enable_http_logging
     FROM
@@ -242,6 +229,19 @@ BEGIN
         key = 'enable_http_logging';
     -- Only proceed if HTTP logging is enabled
     IF v_enable_http_logging THEN
+        -- Get the endpoint and configuration from the config table
+        SELECT
+            value INTO v_endpoint
+        FROM
+            keyhippo_internal.config
+        WHERE
+            key = 'audit_log_endpoint';
+        SELECT
+            value::uuid INTO v_installation_uuid
+        FROM
+            keyhippo_internal.config
+        WHERE
+            key = 'installation_uuid';
         -- Prepare the payload
         v_payload = jsonb_build_object('id', NEW.id, 'timestamp', NEW.timestamp, 'action', NEW.action, 'table_name', NEW.table_name, 'user_id', NEW.user_id, 'function_name', NEW.function_name, 'data', NEW.data, 'installation_uuid', v_installation_uuid);
         -- Make the HTTP request

--- a/extension/keyhippo--0.0.42.sql
+++ b/extension/keyhippo--0.0.42.sql
@@ -239,10 +239,30 @@ $$
 LANGUAGE plpgsql
 SECURITY DEFINER;
 
-CREATE TRIGGER audit_log_notify
-    AFTER INSERT ON keyhippo.audit_log
-    FOR EACH ROW
-    EXECUTE FUNCTION keyhippo.notify_audit_change ();
+-- Function to enable the audit_log_notify trigger
+CREATE OR REPLACE FUNCTION keyhippo_internal.enable_audit_log_notify ()
+    RETURNS VOID
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    AS $$
+BEGIN
+    CREATE TRIGGER keyhippo_audit_log_notify
+        AFTER INSERT ON keyhippo.audit_log
+        FOR EACH ROW
+        EXECUTE FUNCTION keyhippo.notify_audit_change ( );
+END;
+$$;
+
+-- Function to disable the audit_log_notify trigger
+CREATE OR REPLACE FUNCTION keyhippo_internal.disable_audit_log_notify ()
+    RETURNS VOID
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    AS $$
+BEGIN
+    DROP TRIGGER IF EXISTS keyhippo_audit_log_notify ON keyhippo.audit_log;
+END;
+$$;
 
 CREATE OR REPLACE FUNCTION keyhippo.is_authorized (target_resource regclass, required_permission text)
     RETURNS boolean

--- a/extension/keyhippo--0.0.42.sql
+++ b/extension/keyhippo--0.0.42.sql
@@ -268,6 +268,18 @@ BEGIN
         AFTER INSERT ON keyhippo.audit_log
         FOR EACH ROW
         EXECUTE FUNCTION keyhippo_internal.notify_audit_change ( );
+    -- Update the config to enable HTTP logging
+    UPDATE
+        keyhippo_internal.config
+    SET
+        value = 'true'
+    WHERE
+        key = 'enable_http_logging';
+    -- If the config doesn't exist, insert it
+    INSERT INTO keyhippo_internal.config (key, value, description)
+        VALUES ('enable_http_logging', 'true', 'Flag to enable/disable HTTP logging')
+    ON CONFLICT (key)
+        DO NOTHING;
 END;
 $$;
 
@@ -278,7 +290,20 @@ CREATE OR REPLACE FUNCTION keyhippo_internal.disable_audit_log_notify ()
     SECURITY DEFINER
     AS $$
 BEGIN
+    -- Drop the trigger if it exists
     DROP TRIGGER IF EXISTS keyhippo_audit_log_notify ON keyhippo.audit_log;
+    -- Update the config to disable HTTP logging
+    UPDATE
+        keyhippo_internal.config
+    SET
+        value = 'false'
+    WHERE
+        key = 'enable_http_logging';
+    -- If the config doesn't exist, insert it
+    INSERT INTO keyhippo_internal.config (key, value, description)
+        VALUES ('enable_http_logging', 'false', 'Flag to enable/disable HTTP logging')
+    ON CONFLICT (key)
+        DO NOTHING;
 END;
 $$;
 

--- a/extension/keyhippo--0.0.42.sql
+++ b/extension/keyhippo--0.0.42.sql
@@ -263,7 +263,8 @@ CREATE OR REPLACE FUNCTION keyhippo_internal.enable_audit_log_notify ()
     SECURITY DEFINER
     AS $$
 BEGIN
-    CREATE TRIGGER keyhippo_audit_log_notify
+    -- Create the trigger
+    CREATE OR REPLACE TRIGGER keyhippo_audit_log_notify
         AFTER INSERT ON keyhippo.audit_log
         FOR EACH ROW
         EXECUTE FUNCTION keyhippo_internal.notify_audit_change ( );

--- a/extension/keyhippo--0.0.42.sql
+++ b/extension/keyhippo--0.0.42.sql
@@ -171,42 +171,42 @@ $$
 LANGUAGE plpgsql
 SECURITY DEFINER;
 
-CREATE TRIGGER audit_keyhippo_rbac_groups
+CREATE TRIGGER keyhippo_audit_rbac_groups
     AFTER INSERT OR UPDATE OR DELETE ON keyhippo_rbac.groups
     FOR EACH ROW
     EXECUTE FUNCTION keyhippo.log_table_change ();
 
-CREATE TRIGGER audit_keyhippo_rbac_roles
+CREATE TRIGGER keyhippo_audit_rbac_roles
     AFTER INSERT OR UPDATE OR DELETE ON keyhippo_rbac.roles
     FOR EACH ROW
     EXECUTE FUNCTION keyhippo.log_table_change ();
 
-CREATE TRIGGER audit_keyhippo_rbac_permissions
+CREATE TRIGGER keyhippo_audit_rbac_permissions
     AFTER INSERT OR UPDATE OR DELETE ON keyhippo_rbac.permissions
     FOR EACH ROW
     EXECUTE FUNCTION keyhippo.log_table_change ();
 
-CREATE TRIGGER audit_keyhippo_rbac_role_permissions
+CREATE TRIGGER keyhippo_audit_rbac_role_permissions
     AFTER INSERT OR UPDATE OR DELETE ON keyhippo_rbac.role_permissions
     FOR EACH ROW
     EXECUTE FUNCTION keyhippo.log_table_change ();
 
-CREATE TRIGGER audit_keyhippo_rbac_user_group_roles
+CREATE TRIGGER keyhippo_audit_rbac_user_group_roles
     AFTER INSERT OR UPDATE OR DELETE ON keyhippo_rbac.user_group_roles
     FOR EACH ROW
     EXECUTE FUNCTION keyhippo.log_table_change ();
 
-CREATE TRIGGER audit_keyhippo_scopes
+CREATE TRIGGER keyhippo_audit_scopes
     AFTER INSERT OR UPDATE OR DELETE ON keyhippo.scopes
     FOR EACH ROW
     EXECUTE FUNCTION keyhippo.log_table_change ();
 
-CREATE TRIGGER audit_keyhippo_scope_permissions
+CREATE TRIGGER keyhippo_audit_scope_permissions
     AFTER INSERT OR UPDATE OR DELETE ON keyhippo.scope_permissions
     FOR EACH ROW
     EXECUTE FUNCTION keyhippo.log_table_change ();
 
-CREATE TRIGGER audit_keyhippo_api_key_metadata
+CREATE TRIGGER keyhippo_audit_api_key_metadata
     AFTER INSERT OR UPDATE OR DELETE ON keyhippo.api_key_metadata
     FOR EACH ROW
     EXECUTE FUNCTION keyhippo.log_table_change ();
@@ -1076,7 +1076,7 @@ END;
 $$;
 
 -- Create a trigger to assign the default role to new users
-CREATE TRIGGER assign_default_role_trigger
+CREATE TRIGGER keyhippo_assign_default_role_trigger
     AFTER INSERT ON auth.users
     FOR EACH ROW
     EXECUTE FUNCTION keyhippo.assign_default_role ();

--- a/extension/keyhippo--0.0.42.sql
+++ b/extension/keyhippo--0.0.42.sql
@@ -211,7 +211,7 @@ CREATE TRIGGER keyhippo_audit_api_key_metadata
     FOR EACH ROW
     EXECUTE FUNCTION keyhippo.log_table_change ();
 
-CREATE OR REPLACE FUNCTION keyhippo.notify_audit_change ()
+CREATE OR REPLACE FUNCTION keyhippo_internal.notify_audit_change ()
     RETURNS TRIGGER
     AS $$
 DECLARE
@@ -266,7 +266,7 @@ BEGIN
     CREATE TRIGGER keyhippo_audit_log_notify
         AFTER INSERT ON keyhippo.audit_log
         FOR EACH ROW
-        EXECUTE FUNCTION keyhippo.notify_audit_change ( );
+        EXECUTE FUNCTION keyhippo_internal.notify_audit_change ( );
 END;
 $$;
 

--- a/extension/keyhippo.control
+++ b/extension/keyhippo.control
@@ -1,5 +1,5 @@
 # keyhippo extension
 comment = 'RLS-compatible API keys for PostgreSQL'
-default_version = '1.0.0'
+default_version = '1.0.1'
 module_pathname = '$libdir/keyhippo/extension'
 relocatable = true

--- a/extension/keyhippo.control
+++ b/extension/keyhippo.control
@@ -1,5 +1,5 @@
 # keyhippo extension
 comment = 'RLS-compatible API keys for PostgreSQL'
-default_version = '0.0.42'
+default_version = '1.0.0'
 module_pathname = '$libdir/keyhippo/extension'
 relocatable = true

--- a/tests/tests.sql
+++ b/tests/tests.sql
@@ -1,5 +1,8 @@
 BEGIN;
 SET search_path TO keyhippo, keyhippo_rbac, public, auth;
+-- Enable audit log trigger
+SELECT
+    keyhippo_internal.enable_audit_log_notify ();
 -- Create test users and set up authentication
 DO $$
 DECLARE


### PR DESCRIPTION
This PR implements configurable HTTP audit log forwarding for KeyHippo.

The feature allows users to send audit log events to an external endpoint for centralized logging and analysis. I'll be adding related features this week as part of KeyHippo's first [Launch Week](https://www.keyhippo.com/launch-week/0).

Main changes:
- Added new configuration options in `keyhippo_internal.config` table for audit log settings
- Implemented `keyhippo_internal.notify_audit_change()` function to handle audit log forwarding
- Created `keyhippo_internal.enable_audit_log_notify()` and `keyhippo_internal.disable_audit_log_notify()` functions to manage the audit log trigger
- Updated `keyhippo.initialize_keyhippo()` to set up initial audit log configurations
- Added an installation UUID to uniquely identify each KeyHippo instance

Configuration options:
- `audit_log_endpoint`: URL of the external audit log ingest endpoint
- `enable_http_logging`: Boolean flag to enable/disable HTTP audit log forwarding
- `installation_uuid`: Unique identifier for the KeyHippo installation

The feature is designed to be off by default and can be enabled by calling `keyhippo_internal.enable_audit_log_notify()`.

[Mega Launch Week day 2!](https://launchweek.dev/lw/MEGA)
